### PR TITLE
Use the browsers docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # Use the lowest supported version of Node (specified in package.json "engines")
-      - image: circleci/node:6
+      - image: circleci/node:6-browsers
 
     working_directory: ~/example-ember
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TodoMVC example application using Ember
+# TodoMVC example application using Ember [![CircleCI](https://circleci.com/gh/percy/example-ember/tree/master.svg?style=svg)](https://circleci.com/gh/percy/example-ember/tree/master)
 
 This is the example application that's used in [Percy's Ember tutorial](https://percy.io/docs/tutorials/ember).
 


### PR DESCRIPTION
## What is this?

I accidently left off `-browsers` from the docker image circle uses,
which prevents us from running the tests (since they run in chrome)